### PR TITLE
0831_채예은

### DIFF
--- a/Samsung_CT/원자충돌/원자충돌_채예은.py
+++ b/Samsung_CT/원자충돌/원자충돌_채예은.py
@@ -1,0 +1,53 @@
+import sys
+
+input = sys.stdin.readline
+
+DIRECTION = ((-1, 0), (-1, 1), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1), (-1, -1))
+
+n, M, k = map(int, input().split())
+atoms = [list(map(int, input().split())) for _ in range(M)]
+
+for _ in range(k):
+    # 이동
+    place_dic = {}
+    new_atoms = []
+    for atom in atoms:
+        i, j, m, s, d = atom
+        ni, nj = (i+DIRECTION[d][0]*s) % n, (j+DIRECTION[d][1]*s) % n
+        ni = n if ni == 0 else ni
+        nj = n if nj == 0 else nj
+        place_dic[(ni, nj)] = place_dic.get((ni, nj), []) + [[m, s, d]]
+
+    # 합성 & 쪼개기
+    for key, val in place_dic.items():
+        if len(val) < 2:
+            m, s, d = val[0]
+            new_atoms.append([key[0], key[1], m, s, d])
+            continue
+        m_sum = 0
+        s_sum = 0
+        d_stan = val[0][2] % 2  # 홀수 -> 대각선, 짝수 -> 상하좌우
+        d_flag = 0
+        for m, s, d in val:
+            m_sum += m
+            s_sum += s
+            if d%2 != d_stan:
+                d_flag = 1  # 다름! -> 대각선으로 퍼짐
+        # 분할
+        nm = m_sum//5
+        if nm == 0:  # 질량이 0이면 소멸
+            continue
+        ns = s_sum//len(val)
+        for dir in range(4):
+            if d_flag:  # 대각선
+                new_atoms.append([key[0], key[1], nm, ns, dir*2+1])
+            else:  # 상하좌우
+                new_atoms.append([key[0], key[1], nm, ns, dir*2])
+
+    atoms = new_atoms
+
+result = 0
+for atom in atoms:
+    result += atom[2]
+
+print(result)


### PR DESCRIPTION
# 원자 충돌 :atom_symbol:
- 8개의 방향(상하좌우+대각선)을 DIRECTION으로 정의해서 품
- matrix를 직접 그리지 않고 원자들의 좌표값을 리스트에 저장하여 좌표값을 변화시킨 후(이동) 딕셔너리를 통해 같은 칸에 겹치게 되는 원자들을 식별해냈다.
- 그래서 딕셔너리의 값이 2개 이상이면 2개 이상의 원자가 한 칸에 있는 것이므로 합성 & 쪼개기를 진행했다.
- 그리고 딕셔너리 값이 2개 이상이든 아니든 최종적으로 new_atoms에 새로운 좌표의 원자들을 저장한 후 턴 마지막에 `atoms = new_atoms` 로 원자 리스트를 갱신했다.

### 충돌 이후 쪼개지는 원자들의 방향 설정

- 원자 충돌 시, 방향을 상하좌우 or 대각선 으로 분류해서
  - 두 종류가 섞여있으면 -> 쪼개지는 원자의 방향이 대각선
  - 섞여있지 않으면 -> 쪼개지는 원자의 방향이 상하좌우

- 상하좌우 방향의 인덱스는 짝수이고, 대각선의 인덱스는 홀수인걸 통해 방향이 섞여있는지 아닌지 판단함.

- `d_stan` 과 `d_flag` 를 정의해 val[0]의 방향인 `d_stan` 을 들고다니면서 종류가 다른 방향이 나오면 `d_flag`를 `1`로 켜주었다!