### PR TITLE
0928_이성재

### DIFF
--- a/Programmers/Level2_양궁대회/Level2_양궁대회_이성재2.py
+++ b/Programmers/Level2_양궁대회/Level2_양궁대회_이성재2.py
@@ -1,0 +1,36 @@
+def cal_diff(ryan_info, apeach_info):
+    result = 0
+    for i in range(10):
+        if ryan_info[i] == apeach_info[i] == 0:
+            continue
+        elif ryan_info[i] > apeach_info[i]:
+            result += 10 - i
+        else:
+            result -= 10 - i
+    return result
+
+
+def solution(n, info):
+    ryan_info = [0] * 11
+    max_diff = 0
+    answer = [-1]
+
+    def backtrack(level, arrow_cnt):
+        nonlocal max_diff, answer
+        if level == -1:
+            diff = cal_diff(ryan_info, info)
+            if max_diff < diff:
+                max_diff = diff
+                answer = ryan_info[:]
+            return
+
+        if arrow_cnt < n:
+            ryan_info[level] += 1
+            backtrack(level, arrow_cnt + 1)
+            ryan_info[level] -= 1
+
+        backtrack(level - 1, arrow_cnt)
+
+    backtrack(10, 0)
+
+    return answer

--- a/Programmers/Level3_양과늑대/Level3_양과늑대_이성재.py
+++ b/Programmers/Level3_양과늑대/Level3_양과늑대_이성재.py
@@ -1,0 +1,39 @@
+def solution(info, edges):
+    def backtrack(sheep, wolf):
+        nonlocal answer
+        if sheep <= wolf:
+            return
+        answer = max(answer, sheep)
+
+        for i in range(n):
+            if not adjacency[i] or visited[i]:
+                continue
+
+            visited[i] = True
+            adjacency[i] = False
+            for nxt in graph[i]:
+                adjacency[nxt] = True
+
+            backtrack(sheep + int(info[i] == 0), wolf + int(info[i] == 1))
+
+            visited[i] = False
+            adjacency[i] = True
+            for nxt in graph[i]:
+                adjacency[nxt] = False
+
+    n = len(info)
+    graph = [[] for _ in range(n)]
+    for p, c in edges:
+        graph[p].append(c)
+
+    visited = [False] * n
+    adjacency = [False] * n  # 갈 수 있는 노드 표시
+
+    visited[0] = True
+    for nxt in graph[0]:
+        adjacency[nxt] = True
+
+    answer = 0
+    backtrack(1, 0)
+
+    return answer


### PR DESCRIPTION
# 0928

## Level 2 양궁대회 🎯 

- 완전탐색을 했습니다.
- 이전 풀이에서는 `combinations_with_replacement`를 사용했는데, 이번에는 재귀함수로 풀었습니다.
- 중복조합이니까 (11)H(n) 이고, n = 10일 때 184756이었습니다.
- 점수 차이가 최대로 큰 경우 중 낮은 점수를 많이 쏴야하므로 완전탐색을 할 때 낮은 점수를 먼저 쏴보도록 했습니다.



## Level 3 양과 늑대 🐑 🐺 

- 백트래킹을 했습니다.
- 일반적인 트리의 순회(dfs, bfs) 처럼 진행되지 않고 갈 수 있는 인접 노드로 모두 탐색해보아야했습니다.
- 다음으로 탐색해볼 수 있는 노드들을 체크하기 위해 `adjacency` 배열을 이용했고, 방문한 노드를 체크하기위해 `visited` 배열을 이용했습니다.
- 갈 수 있는 노드 중 방문하지 않은 노드를 방문하면서 양과 늑대의 수를 세주고, 양이 더 적어지면 가지치기했습니다.