### PR TITLE
1109_이성재

### DIFF
--- a/Programmers/Level2_두큐합같게만들기/Level2_두큐합같게만들기_이성재.py
+++ b/Programmers/Level2_두큐합같게만들기/Level2_두큐합같게만들기_이성재.py
@@ -1,0 +1,28 @@
+from collections import deque
+
+
+def solution(queue1, queue2):
+    n = len(queue1)
+
+    left = sum(queue1)
+    right = sum(queue2)
+
+    queue1 = deque(queue1)
+    queue2 = deque(queue2)
+
+    for cnt in range(3 * n):
+        if left < right:
+            num = queue2.popleft()
+            queue1.append(num)
+            left += num
+            right -= num
+
+        elif left > right:
+            num = queue1.popleft()
+            queue2.append(num)
+            left -= num
+            right += num
+        else:
+            return cnt
+
+    return -1

--- a/Programmers/Level3_등산코스정하기/Level3_등산코스정하기_이성재.py
+++ b/Programmers/Level3_등산코스정하기/Level3_등산코스정하기_이성재.py
@@ -1,0 +1,48 @@
+from heapq import heappop, heappush
+
+
+def solution(n, paths, gates, summits):
+    is_gate = [False] * (n + 1)
+    is_summit = [False] * (n + 1)
+
+    for gate in gates:
+        is_gate[gate] = True
+    for summit in summits:
+        is_summit[summit] = True
+
+    graph = [[] for _ in range(n + 1)]
+    for i, j, w in paths:
+        graph[i].append((j, w))
+        graph[j].append((i, w))
+
+    def get_min_intensity(start_summit):
+        heap = [(0, start_summit)]
+        intensities = [1e10] * (n + 1)
+        intensities[start_summit] = 0
+        while heap:
+            cur_intensity, node = heappop(heap)
+            if intensities[node] < cur_intensity:
+                continue
+
+            if is_gate[node]:
+                return cur_intensity
+
+            for nxt_node, nxt_cost in graph[node]:
+                if is_summit[nxt_node]:
+                    continue
+                if max(cur_intensity, nxt_cost) >= intensities[nxt_node]:
+                    continue
+                intensities[nxt_node] = max(cur_intensity, nxt_cost)
+                heappush(heap, (max(cur_intensity, nxt_cost), nxt_node))
+
+        return 1e10
+
+    min_intensity = 1e10
+    min_summit = -1
+    for summit in sorted(summits):
+        result = get_min_intensity(summit)
+        if result < min_intensity:
+            min_intensity = result
+            min_summit = summit
+
+    return [min_summit, min_intensity]


### PR DESCRIPTION
# 1109
## 두 큐 합 같게 만들기
- 큐 두 개를 만들고 두 큐 합이 더 큰 쪽에서 원소를 popleft하고 더 작은 쪽으로 append해주었다.
- 큐 합을 매번 계산하지 않고 변수를 만들어서 관리해주었다.
- 연산을 총 3n번 하고도 두 큐 합이 같아지지 않으면 -1을 반환했다. 이 때 2n이 아니라 3n인 이유는 기억이 나질 않는다...

## 등산코스 정하기
- 우선 등산코스를 산봉우리에서 게이트로 단방향만 찾아주면 되었다.
- 다익스트라와 비슷하게 풀었다.
- 그리디하게? 현재 intensity가 가장 작은 것부터 heap에서 꺼내와서 다음 노드로 진행했다. 이 때 다익스트라처럼 intensity를 저장한 배열을 이용해서 현재 저장된 값보다 커지는 경우는 탐색을 진행하지 않도록 했다.